### PR TITLE
Add Quarkus example module

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,3 +323,7 @@ curl http://localhost:8080/actuator/metrics
 - Logs estruturados em JSON
 - Diferentes níveis por ambiente
 
+
+## Quarkus Implementation
+
+A simplified Quarkus module is available under `cliente-quarkus`. Run `./mvnw -f cliente-quarkus/pom.xml quarkus:dev` to start the API.

--- a/cliente-quarkus/README.md
+++ b/cliente-quarkus/README.md
@@ -1,0 +1,11 @@
+# Cliente Quarkus API
+
+This module contains a simple Quarkus-based REST API implementing the same endpoints as the original Spring application.
+
+## Build and Run
+
+```bash
+./mvnw -f cliente-quarkus/pom.xml quarkus:dev
+```
+
+The API will be available at `http://localhost:8080`.

--- a/cliente-quarkus/pom.xml
+++ b/cliente-quarkus/pom.xml
@@ -1,0 +1,59 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>br.com.fiap</groupId>
+    <artifactId>cliente-quarkus</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <quarkus.platform.version>3.10.0</quarkus.platform.version>
+        <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
+        <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${quarkus.platform.group-id}</groupId>
+                <artifactId>${quarkus.platform.artifact-id}</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-resteasy-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-maven-plugin</artifactId>
+                <version>${quarkus.platform.version}</version>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/dto/ClienteDTO.java
+++ b/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/dto/ClienteDTO.java
@@ -1,0 +1,17 @@
+package br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.dto;
+
+import java.time.LocalDate;
+
+public class ClienteDTO {
+    public Long id;
+    public String nome;
+    public String cpf;
+    public LocalDate dataNascimento;
+    public String logradouro;
+    public String numero;
+    public String complemento;
+    public String bairro;
+    public String cidade;
+    public String estado;
+    public String cep;
+}

--- a/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/entity/Cliente.java
+++ b/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/entity/Cliente.java
@@ -1,0 +1,42 @@
+package br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.entity;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "clientes")
+public class Cliente extends PanacheEntity {
+
+    @Column(nullable = false)
+    public String nome;
+
+    @Column(nullable = false, unique = true, length = 14)
+    public String cpf;
+
+    @Column(name = "data_nascimento")
+    public LocalDate dataNascimento;
+
+    @Column
+    public String logradouro;
+
+    @Column
+    public String numero;
+
+    @Column
+    public String complemento;
+
+    @Column
+    public String bairro;
+
+    @Column
+    public String cidade;
+
+    @Column
+    public String estado;
+
+    @Column(length = 9)
+    public String cep;
+}

--- a/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/resource/ClienteResource.java
+++ b/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/resource/ClienteResource.java
@@ -1,0 +1,59 @@
+package br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.resource;
+
+import br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.dto.ClienteDTO;
+import br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.entity.Cliente;
+import br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.service.ClienteService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import java.net.URI;
+import java.util.List;
+
+@Path("/clientes")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ClienteResource {
+
+    @Inject
+    ClienteService service;
+
+    @POST
+    public Response criar(ClienteDTO dto) {
+        Cliente cliente = service.criar(dto);
+        return Response.created(URI.create("/clientes/" + cliente.id)).entity(cliente).build();
+    }
+
+    @GET
+    public List<Cliente> listar() {
+        return service.listarTodos();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Response buscar(@PathParam("id") Long id) {
+        return service.buscarPorId(id)
+                .map(Response::ok)
+                .orElse(Response.status(Response.Status.NOT_FOUND))
+                .build();
+    }
+
+    @PUT
+    @Path("/{id}")
+    public Response atualizar(@PathParam("id") Long id, ClienteDTO dto) {
+        return service.atualizar(id, dto)
+                .map(Response::ok)
+                .orElse(Response.status(Response.Status.NOT_FOUND))
+                .build();
+    }
+
+    @DELETE
+    @Path("/{id}")
+    public Response deletar(@PathParam("id") Long id) {
+        boolean removed = service.deletar(id);
+        if (removed) {
+            return Response.noContent().build();
+        }
+        return Response.status(Response.Status.NOT_FOUND).build();
+    }
+}

--- a/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/service/ClienteService.java
+++ b/cliente-quarkus/src/main/java/br/com/fiap/tech_challenge_4a_fase_cliente/quarkus/service/ClienteService.java
@@ -1,0 +1,55 @@
+package br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.service;
+
+import br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.entity.Cliente;
+import br.com.fiap.tech_challenge_4a_fase_cliente.quarkus.dto.ClienteDTO;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import java.util.List;
+import java.util.Optional;
+
+@ApplicationScoped
+public class ClienteService {
+
+    public List<Cliente> listarTodos() {
+        return Cliente.listAll();
+    }
+
+    public Optional<Cliente> buscarPorId(Long id) {
+        return Cliente.findByIdOptional(id);
+    }
+
+    @Transactional
+    public Cliente criar(ClienteDTO dto) {
+        Cliente cliente = new Cliente();
+        preencher(cliente, dto);
+        cliente.persist();
+        return cliente;
+    }
+
+    @Transactional
+    public Optional<Cliente> atualizar(Long id, ClienteDTO dto) {
+        Optional<Cliente> clienteOpt = Cliente.findByIdOptional(id);
+        clienteOpt.ifPresent(c -> {
+            preencher(c, dto);
+        });
+        return clienteOpt;
+    }
+
+    @Transactional
+    public boolean deletar(Long id) {
+        return Cliente.deleteById(id);
+    }
+
+    private void preencher(Cliente c, ClienteDTO dto) {
+        c.nome = dto.nome;
+        c.cpf = dto.cpf;
+        c.dataNascimento = dto.dataNascimento;
+        c.logradouro = dto.logradouro;
+        c.numero = dto.numero;
+        c.complemento = dto.complemento;
+        c.bairro = dto.bairro;
+        c.cidade = dto.cidade;
+        c.estado = dto.estado;
+        c.cep = dto.cep;
+    }
+}

--- a/cliente-quarkus/src/main/resources/application.properties
+++ b/cliente-quarkus/src/main/resources/application.properties
@@ -1,0 +1,6 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:default;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=sa
+quarkus.datasource.password=sa
+quarkus.hibernate-orm.database.generation=drop-and-create
+quarkus.hibernate-orm.sql-load-script=import.sql


### PR DESCRIPTION
## Summary
- add new `cliente-quarkus` module with Quarkus REST API
- update README with instructions to run the Quarkus version

## Testing
- `./mvnw -q test -f cliente-quarkus/pom.xml` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_688031b626808330b18817a4d0b0a874